### PR TITLE
CiviCRM 5.68 compatibility and PHP 8 Compatibility

### DIFF
--- a/dbmonitor.civix.php
+++ b/dbmonitor.civix.php
@@ -102,13 +102,7 @@ function _dbmonitor_civix_civicrm_config(&$config = NULL) {
 
   $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
-
-  if (is_array($template->template_dir)) {
-    array_unshift($template->template_dir, $extDir);
-  }
-  else {
-    $template->template_dir = [$extDir, $template->template_dir];
-  }
+  $template->addTemplateDir($extDir);
 
   $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
   set_include_path($include_path);


### PR DESCRIPTION
This fixes an issue with CiviCRm 5.68 and PHP 8. 