### PR TITLE
Ensure html attributes are escaped in templates

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -16,11 +16,11 @@
   </urls>
   <releaseDate>2024-05-08</releaseDate>
   <version>1.1.1</version>
-  <develStage></develStage>
+  <develStage/>
   <compatibility>
-    <ver>5.0</ver>
+    <ver>5.65</ver>
   </compatibility>
-  <comments></comments>
+  <comments/>
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>
   </classloader>

--- a/templates/CRM/Dbmonitor/Page/ProcessList.tpl
+++ b/templates/CRM/Dbmonitor/Page/ProcessList.tpl
@@ -40,8 +40,8 @@
                 <td><a title="{$query.sql}">{$query.sql_short}</a></td>
                 <td>{$query.runtime_text}</td>
                 <td>
-                    <a href="{crmURL p="civicrm/admin/dbprocesslist" q="op=kill&id=$query_id"}" title="{ts}Cancel the query{/ts}" class="action-item crm-hover-button">{ts}Kill{/ts}</a>
-                    <a href="{crmURL p="civicrm/admin/dbprocesslist" q="op=export&id=$query_id"}" title="{ts}Export SQL{/ts}" class="action-item crm-hover-button">{ts}Export{/ts}</a>
+                    <a href="{crmURL p="civicrm/admin/dbprocesslist" q="op=kill&id=$query_id"}" title="{ts escape='htmlattribute'}Cancel the query{/ts}" class="action-item crm-hover-button">{ts}Kill{/ts}</a>
+                    <a href="{crmURL p="civicrm/admin/dbprocesslist" q="op=export&id=$query_id"}" title="{ts escape='htmlattribute'}Export SQL{/ts}" class="action-item crm-hover-button">{ts}Export{/ts}</a>
                 </td>
             </tr>
         {/foreach}
@@ -76,7 +76,7 @@
                 <td><a title="{$query.sql}">{$query.sql_short}</a></td>
                 <td>{$query.runtime_text}</td>
                 <td>
-                    <a href="{crmURL p="civicrm/admin/dbprocesslist" q="op=export&id=$query_id"}" title="{ts}Export SQL{/ts}" class="action-item crm-hover-button">{ts}Export{/ts}</a>
+                    <a href="{crmURL p="civicrm/admin/dbprocesslist" q="op=export&id=$query_id"}" title="{ts escape='htmlattribute'}Export SQL{/ts}" class="action-item crm-hover-button">{ts}Export{/ts}</a>
                 </td>
             </tr>
         {/foreach}


### PR DESCRIPTION
This adds escape='htmlattribute' to all translations within tags, which ensures any special characters in the translated string
are properly escaped and don't break out of the quotes or cause other problems.

See https://github.com/civicrm/civicrm-core/pull/26792

Note: This requires CiviCRM 5.65 at minimum.