### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/api/v3/DBMonitor.php
+++ b/api/v3/DBMonitor.php
@@ -57,7 +57,7 @@ function civicrm_api3_d_b_monitor_probe(&$params)
                         'option.limit' => 1,
                     ]
                 );
-            } catch (CiviCRM_API3_Exception $ex) {
+            } catch (CRM_Core_Exception $ex) {
                 // contact doesn't seem to have a primary email
             }
         }


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.